### PR TITLE
fix: correcting specification link on homepage

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -66,7 +66,7 @@ params:
       a party to get a high degree of assurances about the software.
     
     Links: |
-      - [Specification](https://github.com/SBOMit/website)
+      - [Specification](https://github.com/SBOMit/specification)
       - [About](/about)
     
     Additional: |


### PR DESCRIPTION
Fixing link on homepage for the specification. it was pointing to the website repo, and should be pointing to the specification.